### PR TITLE
disableProvisioningProfileSpecifier and destination added:

### DIFF
--- a/xcodebuild/build.go
+++ b/xcodebuild/build.go
@@ -48,12 +48,11 @@ type CommandBuilder struct {
 	destination   string
 
 	// buildsetting
-	forceDevelopmentTeam                string
-	forceProvisioningProfileSpecifier   string
-	forceProvisioningProfile            string
-	forceCodeSignIdentity               string
-	disableCodesign                     bool
-	disableProvisioningProfileSpecifier bool
+	forceDevelopmentTeam              string
+	forceProvisioningProfileSpecifier string
+	forceProvisioningProfile          string
+	forceCodeSignIdentity             string
+	disableCodesign                   bool
 
 	// buildaction
 	customBuildActions []string
@@ -148,12 +147,6 @@ func (c *CommandBuilder) SetDisableCodesign(disable bool) *CommandBuilder {
 	return c
 }
 
-// SetDisableProvisioningProfileSpecifier ...
-func (c *CommandBuilder) SetDisableProvisioningProfileSpecifier(disable bool) *CommandBuilder {
-	c.disableProvisioningProfileSpecifier = disable
-	return c
-}
-
 func (c *CommandBuilder) cmdSlice() []string {
 	slice := []string{toolName}
 
@@ -173,25 +166,28 @@ func (c *CommandBuilder) cmdSlice() []string {
 		slice = append(slice, "-configuration", c.configuration)
 	}
 
-	if c.forceDevelopmentTeam != "" {
-		slice = append(slice, fmt.Sprintf("DEVELOPMENT_TEAM=%s", c.forceDevelopmentTeam))
-	}
-
-	if c.forceProvisioningProfileSpecifier != "" {
-		slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE_SPECIFIER=%s", c.forceProvisioningProfileSpecifier))
-	} else if c.disableProvisioningProfileSpecifier {
-		slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE_SPECIFIER="))
-	}
-
-	if c.forceProvisioningProfile != "" {
-		slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE=%s", c.forceProvisioningProfile))
-	}
-
-	if c.forceCodeSignIdentity != "" {
-		slice = append(slice, fmt.Sprintf("CODE_SIGN_IDENTITY=%s", c.forceCodeSignIdentity))
-	} else if c.disableCodesign {
+	if c.disableCodesign {
 		slice = append(slice, "CODE_SIGN_IDENTITY=")
 		slice = append(slice, "CODE_SIGNING_REQUIRED=NO")
+		slice = append(slice, "PROVISIONING_PROFILE_SPECIFIER=")
+		slice = append(slice, "PROVISIONING_PROFILE=")
+		slice = append(slice, "DEVELOPMENT_TEAM=")
+	} else {
+		if c.forceDevelopmentTeam != "" {
+			slice = append(slice, fmt.Sprintf("DEVELOPMENT_TEAM=%s", c.forceDevelopmentTeam))
+		}
+
+		if c.forceProvisioningProfileSpecifier != "" {
+			slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE_SPECIFIER=%s", c.forceProvisioningProfileSpecifier))
+		}
+
+		if c.forceProvisioningProfile != "" {
+			slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE=%s", c.forceProvisioningProfile))
+		}
+
+		if c.forceCodeSignIdentity != "" {
+			slice = append(slice, fmt.Sprintf("CODE_SIGN_IDENTITY=%s", c.forceCodeSignIdentity))
+		}
 	}
 
 	if c.destination != "" {

--- a/xcodebuild/build.go
+++ b/xcodebuild/build.go
@@ -45,13 +45,15 @@ type CommandBuilder struct {
 	isWorkspace   bool
 	scheme        string
 	configuration string
+	destination   string
 
 	// buildsetting
-	forceDevelopmentTeam              string
-	forceProvisioningProfileSpecifier string
-	forceProvisioningProfile          string
-	forceCodeSignIdentity             string
-	disableCodesign                   bool
+	forceDevelopmentTeam                string
+	forceProvisioningProfileSpecifier   string
+	forceProvisioningProfile            string
+	forceCodeSignIdentity               string
+	disableCodesign                     bool
+	disableProvisioningProfileSpecifier bool
 
 	// buildaction
 	customBuildActions []string
@@ -77,6 +79,12 @@ func NewCommandBuilder(projectPath string, isWorkspace bool, action Action) *Com
 // SetScheme ...
 func (c *CommandBuilder) SetScheme(scheme string) *CommandBuilder {
 	c.scheme = scheme
+	return c
+}
+
+// SetDestination ...
+func (c *CommandBuilder) SetDestination(destination string) *CommandBuilder {
+	c.destination = destination
 	return c
 }
 
@@ -140,6 +148,12 @@ func (c *CommandBuilder) SetDisableCodesign(disable bool) *CommandBuilder {
 	return c
 }
 
+// SetDisableProvisioningProfileSpecifier ...
+func (c *CommandBuilder) SetDisableProvisioningProfileSpecifier(disable bool) *CommandBuilder {
+	c.disableProvisioningProfileSpecifier = disable
+	return c
+}
+
 func (c *CommandBuilder) cmdSlice() []string {
 	slice := []string{toolName}
 
@@ -154,6 +168,7 @@ func (c *CommandBuilder) cmdSlice() []string {
 	if c.scheme != "" {
 		slice = append(slice, "-scheme", c.scheme)
 	}
+
 	if c.configuration != "" {
 		slice = append(slice, "-configuration", c.configuration)
 	}
@@ -161,17 +176,28 @@ func (c *CommandBuilder) cmdSlice() []string {
 	if c.forceDevelopmentTeam != "" {
 		slice = append(slice, fmt.Sprintf("DEVELOPMENT_TEAM=%s", c.forceDevelopmentTeam))
 	}
+
 	if c.forceProvisioningProfileSpecifier != "" {
 		slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE_SPECIFIER=%s", c.forceProvisioningProfileSpecifier))
+	} else if c.disableProvisioningProfileSpecifier {
+		slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE_SPECIFIER="))
 	}
+
 	if c.forceProvisioningProfile != "" {
 		slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE=%s", c.forceProvisioningProfile))
 	}
+
 	if c.forceCodeSignIdentity != "" {
 		slice = append(slice, fmt.Sprintf("CODE_SIGN_IDENTITY=%s", c.forceCodeSignIdentity))
 	} else if c.disableCodesign {
 		slice = append(slice, "CODE_SIGN_IDENTITY=")
 		slice = append(slice, "CODE_SIGNING_REQUIRED=NO")
+	}
+
+	if c.destination != "" {
+		// "-destination" "id=07933176-D03B-48D3-A853-0800707579E6" => (need the plus `"` marks between the `destination` and the `id`)
+		slice = append(slice, "-destination")
+		slice = append(slice, c.destination)
 	}
 
 	slice = append(slice, c.customBuildActions...)


### PR DESCRIPTION
If the disableProvisioningProfileSpecifier is true it will add an empty "PROVISIONING_PROFILE_SPECIFIER=" to the build options.